### PR TITLE
metricbeat securityContext placement

### DIFF
--- a/metricbeat_openshift.yaml
+++ b/metricbeat_openshift.yaml
@@ -112,6 +112,9 @@ spec:
           - /etc/beat.yml
           - -system.hostfs=/hostfs
           name: metricbeat
+          securityContext:
+            runAsUser: 0
+            privileged: true
           volumeMounts:
           - mountPath: /hostfs/sys/fs/cgroup
             name: cgroup
@@ -132,9 +135,6 @@ spec:
               memory: 2Gi
         dnsPolicy: ClusterFirstWithHostNet
         hostNetwork: true # Allows to provide richer host metadata
-        securityContext:
-          runAsUser: 0
-          privileged: true
         terminationGracePeriodSeconds: 30
         volumes:
         - hostPath:


### PR DESCRIPTION
securityContext was in a wrong place and thus pods couldn't be created, after the fix it is OK (tested)